### PR TITLE
Remove references to key lifetime

### DIFF
--- a/protobuf/asym_sign.proto
+++ b/protobuf/asym_sign.proto
@@ -16,13 +16,11 @@
  */
 syntax = "proto3";
 
-import "key_attributes.proto";
-
 package asym_sign;
 
 message OpAsymmetricSignProto {
     string key_name = 1;
-    key_attributes.KeyLifetime key_lifetime = 2;
+    reserved 2;
     bytes hash = 3;
 }
 

--- a/protobuf/asym_verify.proto
+++ b/protobuf/asym_verify.proto
@@ -16,13 +16,11 @@
  */
 syntax = "proto3";
 
-import "key_attributes.proto";
-
 package asym_verify;
 
 message OpAsymmetricVerifyProto {
     string key_name = 1;
-    key_attributes.KeyLifetime key_lifetime = 2;
+    reserved 2;
     bytes hash = 3;
     bytes signature = 4;
 }

--- a/protobuf/destroy_key.proto
+++ b/protobuf/destroy_key.proto
@@ -16,13 +16,11 @@
  */
 syntax = "proto3";
 
-import "key_attributes.proto";
-
 package destroy_key;
 
 message OpDestroyKeyProto {
     string key_name = 1;
-    key_attributes.KeyLifetime key_lifetime = 2;
+    reserved 2;
 }
 
 message ResultDestroyKeyProto { }

--- a/protobuf/export_public_key.proto
+++ b/protobuf/export_public_key.proto
@@ -16,13 +16,11 @@
  */
 syntax = "proto3";
 
-import "key_attributes.proto";
-
 package export_public_key;
 
 message OpExportPublicKeyProto {
    string key_name = 1;
-   key_attributes.KeyLifetime key_lifetime = 2;
+   reserved 2;
 }
 
 message ResultExportPublicKeyProto {

--- a/protobuf/key_attributes.proto
+++ b/protobuf/key_attributes.proto
@@ -18,11 +18,6 @@ syntax = "proto3";
 
 package key_attributes;
 
-enum KeyLifetime {
-   Volatile = 0;
-   Persistent = 1;
-}
-
 enum KeyType {
    HMAC_Key = 0;
    Derivation_Key = 1;
@@ -171,7 +166,7 @@ message KeyAgreement {
 }
 
 message KeyAttributesProto {
-   KeyLifetime key_lifetime = 1;
+   reserved 1;
    KeyType key_type = 2;
    EccCurve ecc_curve = 3;
    oneof algorithm_proto {


### PR DESCRIPTION
This change makes the operations simpler by removing the KeyLifetime
attribute of the keys.
The choice between using permanent or volatile keys is now going to be
done at the provider level with providers using either volatile or
permanent keys.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>