### PR TITLE
Add "derive" usage flag

### DIFF
--- a/protobuf/key_attributes.proto
+++ b/protobuf/key_attributes.proto
@@ -92,4 +92,5 @@ message UsageFlags {
   bool verify_message = 7;
   bool sign_hash = 8;
   bool verify_hash = 9;
+  bool derive = 10;
 }


### PR DESCRIPTION
This commit adds "derive" as a usage flag for keys.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>