### PR TITLE
Add 'psa_' prefix to PSA-related contracts

### DIFF
--- a/protobuf/psa_algorithm.proto
+++ b/protobuf/psa_algorithm.proto
@@ -4,7 +4,7 @@
  */
 syntax = "proto3";
 
-package algorithm;
+package psa_algorithm;
 
 message Algorithm {
   message None {}

--- a/protobuf/psa_destroy_key.proto
+++ b/protobuf/psa_destroy_key.proto
@@ -16,13 +16,8 @@
  */
 syntax = "proto3";
 
-package generate_key;
+package psa_destroy_key;
 
-import "key_attributes.proto";
-
-message Operation {
-  string key_name = 1;
-  key_attributes.KeyAttributes attributes = 2;
-}
+message Operation { string key_name = 1; }
 
 message Result {}

--- a/protobuf/psa_export_public_key.proto
+++ b/protobuf/psa_export_public_key.proto
@@ -16,7 +16,7 @@
  */
 syntax = "proto3";
 
-package export_public_key;
+package psa_export_public_key;
 
 message Operation { string key_name = 1; }
 

--- a/protobuf/psa_generate_key.proto
+++ b/protobuf/psa_generate_key.proto
@@ -16,8 +16,13 @@
  */
 syntax = "proto3";
 
-package destroy_key;
+package psa_generate_key;
 
-message Operation { string key_name = 1; }
+import "psa_key_attributes.proto";
+
+message Operation {
+  string key_name = 1;
+  psa_key_attributes.KeyAttributes attributes = 2;
+}
 
 message Result {}

--- a/protobuf/psa_import_key.proto
+++ b/protobuf/psa_import_key.proto
@@ -16,13 +16,13 @@
  */
 syntax = "proto3";
 
-package import_key;
+package psa_import_key;
 
-import "key_attributes.proto";
+import "psa_key_attributes.proto";
 
 message Operation {
   string key_name = 1;
-  key_attributes.KeyAttributes attributes = 2;
+  psa_key_attributes.KeyAttributes attributes = 2;
   bytes data = 3;
 }
 

--- a/protobuf/psa_key_attributes.proto
+++ b/protobuf/psa_key_attributes.proto
@@ -16,9 +16,9 @@
  */
 syntax = "proto3";
 
-package key_attributes;
+package psa_key_attributes;
 
-import "algorithm.proto";
+import "psa_algorithm.proto";
 
 message KeyAttributes {
   KeyType key_type = 1;
@@ -79,7 +79,7 @@ message KeyType {
 
 message KeyPolicy {
   UsageFlags key_usage_flags = 1;
-  algorithm.Algorithm key_algorithm = 2;
+  psa_algorithm.Algorithm key_algorithm = 2;
 }
 
 message UsageFlags {

--- a/protobuf/psa_sign_hash.proto
+++ b/protobuf/psa_sign_hash.proto
@@ -16,15 +16,14 @@
  */
 syntax = "proto3";
 
-package verify_hash;
+package psa_sign_hash;
 
-import "algorithm.proto";
+import "psa_algorithm.proto";
 
 message Operation {
   string key_name = 1;
-  algorithm.Algorithm.AsymmetricSignature alg = 2;
+  psa_algorithm.Algorithm.AsymmetricSignature alg = 2;
   bytes hash = 3;
-  bytes signature = 4;
 }
 
-message Result {}
+message Result { bytes signature = 1; }

--- a/protobuf/psa_verify_hash.proto
+++ b/protobuf/psa_verify_hash.proto
@@ -16,14 +16,15 @@
  */
 syntax = "proto3";
 
-package sign_hash;
+package psa_verify_hash;
 
-import "algorithm.proto";
+import "psa_algorithm.proto";
 
 message Operation {
   string key_name = 1;
-  algorithm.Algorithm.AsymmetricSignature alg = 2;
+  psa_algorithm.Algorithm.AsymmetricSignature alg = 2;
   bytes hash = 3;
+  bytes signature = 4;
 }
 
-message Result { bytes signature = 1; }
+message Result {}


### PR DESCRIPTION
This commit adds the 'psa_' prefix to all PSA Crypto-derived contracts,
including operations, algorithms and key attributes.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>