### PR TITLE
Add provider ID in list_opcodes operation

### DIFF
--- a/protobuf/list_opcodes.proto
+++ b/protobuf/list_opcodes.proto
@@ -18,6 +18,6 @@ syntax = "proto3";
 
 package list_opcodes;
 
-message Operation {}
+message Operation { uint32 provider_id = 1; } // Cast down to 8 bits
 
 message Result { repeated uint32 opcodes = 1; }


### PR DESCRIPTION
This commit adds a provider ID field in the `list_opcodes` operation
contract; it is needed as the provider of interest (i.e. for which the
opcodes should be retrieved) cannot be assumed to be the one mentioned
in the request header. That is because the request itself needs to
always be directed to the CoreProvider.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>