### PR TITLE
Add ListKeys protobuf contract

### DIFF
--- a/protobuf/list_keys.proto
+++ b/protobuf/list_keys.proto
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Contributors to the Parsec project.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+syntax = "proto3";
+
+package list_keys;
+
+import "psa_key_attributes.proto";
+
+message KeyInfo {
+  uint32 provider_id = 1;
+  string name = 2;
+  psa_key_attributes.KeyAttributes attributes = 3;
+}
+
+message Operation {}
+
+message Result { repeated KeyInfo keys = 1; }


### PR DESCRIPTION
Very simple -- just adds the protobuf contract for `ListKeys`.