### PR TITLE
Use buf to check for breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,11 @@ jobs:
           sudo apt install protobuf-compiler
     - name: Check that the protobuf files compile using protoc
       run: ./ci/check_build.sh
+
+  breaking-changes:
+    name: Check for breaking changes
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Check that there is not breaking changes
+      run: ./ci/check_breaking_changes.sh

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,21 @@
+# Copyright 2021 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is the default config file from https://docs.buf.build/configuration#bufyaml-defaults
+# with minor modifications.
+
+version: v1beta1
+build:
+  roots:
+    - protobuf/
+lint:
+  use:
+    - DEFAULT
+  enum_zero_value_suffix: _NONE
+  rpc_allow_same_request_response: false
+  rpc_allow_google_protobuf_empty_requests: false
+  rpc_allow_google_protobuf_empty_responses: false
+  service_suffix: Service
+breaking:
+  use:
+    - FILE

--- a/ci/check_breaking_changes.sh
+++ b/ci/check_breaking_changes.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euf -o pipefail
+
+# Check for breaking changes using Buf
+
+# Installing buf
+# Installation steps taken from https://docs.buf.build/installation#binary
+BIN="/usr/local/bin"
+VERSION="0.41.0"
+BINARY_NAME="buf"
+HTTPS_GIT="https://github.com/parallaxsecond/parsec-operations.git"
+
+sudo curl -sSL \
+	"https://github.com/bufbuild/buf/releases/download/v${VERSION}/${BINARY_NAME}-$(uname -s)-$(uname -m)" \
+	-o "${BIN}/${BINARY_NAME}"
+sudo chmod +x "${BIN}/${BINARY_NAME}"
+
+sudo buf breaking --against "$HTTPS_GIT#branch=main"


### PR DESCRIPTION
The buf tools is used on the CI to check that there is not breaking
change on the PR compared against the main branch.

In the context of https://github.com/parallaxsecond/parsec/issues/388