### PR TITLE
Example of a breaking change to check CI

### DIFF
--- a/protobuf/list_providers.proto
+++ b/protobuf/list_providers.proto
@@ -14,6 +14,7 @@ message ProviderInfo {
   uint32 version_min = 5;
   uint32 version_rev = 6;
   uint32 id = 7;
+  uint32 toto = 8;
 }
 
 message Operation {}

--- a/protobuf/psa_algorithm.proto
+++ b/protobuf/psa_algorithm.proto
@@ -8,6 +8,10 @@ package psa_algorithm;
 
 message Algorithm {
   message None {}
+  message Tata {
+    uint32 titi = 1;
+    uint32 titi2 = 2;
+  }
   enum Hash {
     HASH_NONE = 0; // This default variant should not be used.
     MD2 = 1 [ deprecated = true ];
@@ -25,6 +29,7 @@ message Algorithm {
     SHA3_256 = 13;
     SHA3_384 = 14;
     SHA3_512 = 15;
+    TOTO = 16;
   }
   message Mac {
     message FullLength {
@@ -149,5 +154,6 @@ message Algorithm {
     AsymmetricEncryption asymmetric_encryption = 7;
     KeyAgreement key_agreement = 8;
     KeyDerivation key_derivation = 9;
+    Tata tata = 10;
   }
 }

--- a/protobuf/psa_key_attributes.proto
+++ b/protobuf/psa_key_attributes.proto
@@ -10,7 +10,7 @@ import "psa_algorithm.proto";
 
 message KeyAttributes {
   KeyType key_type = 1;
-  uint32 key_bits = 2;
+  int32 key_bits = 2;
   KeyPolicy key_policy = 3;
 }
 
@@ -74,7 +74,6 @@ message UsageFlags {
   bool export = 1;
   bool copy = 2;
   bool cache = 3;
-  bool encrypt = 4;
   bool decrypt = 5;
   bool sign_message = 6;
   bool verify_message = 7;


### PR DESCRIPTION
This is an example of some changes on the contracts. Some of them are non-breaking, some of them are. The tool should only point out the breaking ones:
- a field (`encrypt`) is removed
- the type of a field (`key_bits`) is changed

The changes allowed as non-breaking changes in https://github.com/parallaxsecond/parsec/issues/388 are allowed:
- adding a field to a message
- adding a new enum variant
- adding a new oneoff variant