### PR TITLE
Add Parsec admins as code owners of CI files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Rule for CI test files
+ci/*   @parallaxsecond/admin


### PR DESCRIPTION
This is to prevent someone accidentally changing the tests, which could
make harm to Parsec's stability.