### PR TITLE
Add AttestKey and PrepareKeyAttestation

### DIFF
--- a/protobuf/attest_key.proto
+++ b/protobuf/attest_key.proto
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Contributors to the Parsec project.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+syntax = "proto3";
+
+package attest_key;
+
+message AttestationMechanismParams {
+  message ActivateCredential {
+    bytes credential_blob = 1;
+    bytes secret = 2;
+  }
+
+  oneof mechanism { ActivateCredential activate_credential = 1; }
+}
+
+message Operation {
+  string attested_key_name = 1;
+  AttestationMechanismParams parameters = 2;
+  string attesting_key_name = 3;
+}
+
+message AttestationOutput {
+  message ActivateCredential { bytes credential = 1; }
+
+  oneof mechanism { ActivateCredential activate_credential = 1; }
+}
+
+message Result { AttestationOutput output = 1; }

--- a/protobuf/prepare_key_attestation.proto
+++ b/protobuf/prepare_key_attestation.proto
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Contributors to the Parsec project.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+syntax = "proto3";
+
+package prepare_key_attestation;
+
+message PrepareKeyAttestationParams {
+  message ActivateCredential {
+    string attested_key_name = 1;
+    string attesting_key_name = 2;
+  }
+
+  oneof mechanism { ActivateCredential activate_credential = 1; }
+}
+
+message Operation { PrepareKeyAttestationParams parameters = 1; }
+
+message PrepareKeyAttestationOutput {
+  message ActivateCredential {
+    bytes name = 1;
+    bytes public = 2;
+    bytes attesting_key_pub = 3;
+  }
+
+  oneof mechanism { ActivateCredential activate_credential = 1; }
+}
+
+message Result { PrepareKeyAttestationOutput output = 1; }


### PR DESCRIPTION
This commit adds two new operations - AttestKey and
PrepareKeyAttestation, along with a kernel for their parameters.

Fixes #33 